### PR TITLE
Fix for creation of UNIX domain sockets on macOS

### DIFF
--- a/source/SocketRelay.php
+++ b/source/SocketRelay.php
@@ -263,7 +263,7 @@ class SocketRelay implements RelayInterface
                 throw new GoridgeException("socket {$this} unavailable on Windows");
             }
 
-            return socket_create(1, SOCK_STREAM, SOL_SOCKET);
+            return socket_create(AF_UNIX, SOCK_STREAM, 0);
         }
 
         return socket_create(AF_INET, SOCK_STREAM, SOL_TCP);


### PR DESCRIPTION
On macOS, when attempting to connect to a domain socket, I received the following error: `Warning: socket_create(): Unable to create socket [43]: Protocol not supported - #0 `. I was able to resolve the issue by setting the `protocol` parameter of `socket_create()` to `0`, and I changed the `domain` parameter to `AF_UNIX` for clarity. I also tested this change on Alpine Linux (via Docker) and it appears to work.

Additional reference: http://php.net/manual/en/function.socket-create.php#58257