### PR TITLE
Fix `STDIN is not readable` error

### DIFF
--- a/php-src/StreamRelay.php
+++ b/php-src/StreamRelay.php
@@ -140,7 +140,7 @@ class StreamRelay implements RelayInterface
     {
         $meta = stream_get_meta_data($stream);
 
-        return in_array($meta['mode'], ['r', 'rb', 'r+', 'w+', 'a+', 'x+', 'c+'], true);
+        return in_array($meta['mode'], ['r', 'rb', 'r+', 'rb+', 'w+', 'wb+', 'a+', 'ab+', 'x+', 'c+', 'cb+'], true);
     }
 
     /**


### PR DESCRIPTION
Fix for issue #36 