### PR TITLE
refactor(all): fix linter warning, remove `byte` type aliases

### DIFF
--- a/internal/receive.go
+++ b/internal/receive.go
@@ -8,7 +8,7 @@ import (
 )
 
 func ReceiveFrame(relay io.Reader, fr *frame.Frame) error {
-	const op = errors.Op("pipes frame receive")
+	const op = errors.Op("goridge_frame_receive")
 	// header bytes
 	hb := make([]byte, 12)
 	_, err := io.ReadFull(relay, hb)

--- a/pkg/frame/frame_flags.go
+++ b/pkg/frame/frame_flags.go
@@ -1,25 +1,23 @@
 package frame
 
-type Flag byte
-
 // BYTE flags, it means, that we can set multiply flags from this group using bitwise OR
 // For example CONTEXT_SEPARATOR | CODEC_RAW
 const (
-	CONTROL       Flag = 0x01
-	CODEC_RAW     Flag = 0x04 //nolint:stylecheck,golint
-	CODEC_JSON    Flag = 0x08 //nolint:stylecheck,golint
-	CODEC_MSGPACK Flag = 0x10 //nolint:stylecheck,golint
-	CODEC_GOB     Flag = 0x20 //nolint:stylecheck,golint
-	ERROR         Flag = 0x40 //nolint:stylecheck,golint
-	CODEC_PROTO   Flag = 0x80 //nolint:stylecheck,golint
+	CONTROL       byte = 0x01
+	CODEC_RAW     byte = 0x04 //nolint:stylecheck,golint
+	CODEC_JSON    byte = 0x08 //nolint:stylecheck,golint
+	CODEC_MSGPACK byte = 0x10 //nolint:stylecheck,golint
+	CODEC_GOB     byte = 0x20 //nolint:stylecheck,golint
+	ERROR         byte = 0x40 //nolint:stylecheck,golint
+	CODEC_PROTO   byte = 0x80 //nolint:stylecheck,golint
 )
 
 // COMPLEX flags can't be used with Byte flags, because it's value more than 128
 const (
-	RESERVED2 Flag = 0x81
-	RESERVED3 Flag = 0x82
-	RESERVED4 Flag = 0x83
-	RESERVED5 Flag = 0x84
+	RESERVED2 byte = 0x81
+	RESERVED3 byte = 0x82
+	RESERVED4 byte = 0x83
+	RESERVED5 byte = 0x84
 )
 
 type Version byte

--- a/pkg/pipe/pipe.go
+++ b/pkg/pipe/pipe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spiral/goridge/v3/pkg/frame"
 )
 
-// PipeRelay communicate with underlying process using standard streams (STDIN, STDOUT). Attention, use TCP alternative for
+// Relay ... PipeRelay communicate with underlying process using standard streams (STDIN, STDOUT). Attention, use TCP alternative for
 // Windows as more reliable option. This relay closes automatically with the process.
 type Relay struct {
 	in  io.ReadCloser

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -45,7 +45,7 @@ func (c *ClientCodec) put(b *bytes.Buffer) {
 // WriteRequest writes request to the connection. Sequential.
 func (c *ClientCodec) WriteRequest(r *rpc.Request,
 	body interface{}) error {
-	const op = errors.Op("client codec WriteRequest")
+	const op = errors.Op("goridge_write_request")
 	fr := frame.NewFrame()
 	defer func() {
 		// reset the fr

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -117,7 +117,7 @@ func (c *ClientCodec) ReadResponseHeader(r *rpc.Response) error {
 	}
 
 	// check for error
-	if fr.ReadFlags()&byte(frame.ERROR) != 0 {
+	if fr.ReadFlags()&frame.ERROR != 0 {
 		r.Error = string(fr.Payload()[opts[1]:])
 	}
 
@@ -142,15 +142,15 @@ func (c *ClientCodec) ReadResponseBody(out interface{}) error {
 	flags := c.frame.ReadFlags()
 
 	switch {
-	case flags&byte(frame.CODEC_PROTO) != 0:
+	case flags&frame.CODEC_PROTO != 0:
 		return decodeProto(out, c.frame)
-	case flags&byte(frame.CODEC_JSON) != 0:
+	case flags&frame.CODEC_JSON != 0:
 		return decodeJSON(out, c.frame)
-	case flags&byte(frame.CODEC_GOB) != 0:
+	case flags&frame.CODEC_GOB != 0:
 		return decodeGob(out, c.frame)
-	case flags&byte(frame.CODEC_RAW) != 0:
+	case flags&frame.CODEC_RAW != 0:
 		return decodeRaw(out, c.frame)
-	case flags&byte(frame.CODEC_MSGPACK) != 0:
+	case flags&frame.CODEC_MSGPACK != 0:
 		return decodeMsgPack(out, c.frame)
 	default:
 		return errors.E(op, errors.Str("unknown decoder used in frame"))

--- a/pkg/rpc/client_server_test.go
+++ b/pkg/rpc/client_server_test.go
@@ -30,7 +30,7 @@ func (s *testService) Echo(msg string, r *string) error {
 }
 
 // Echo returns error
-func (s *testService) EchoR(msg string, r *string) error {
+func (s *testService) EchoR(_ string, r *string) error {
 	*r = "error"
 	return errors.Str("echoR error")
 }

--- a/pkg/rpc/codec.go
+++ b/pkg/rpc/codec.go
@@ -36,7 +36,7 @@ func NewCodecWithRelay(relay relay.Relay) *Codec {
 
 // WriteResponse marshals response, byte slice or error to remote party.
 func (c *Codec) WriteResponse(r *rpc.Response, body interface{}) error { //nolint:funlen
-	const op = errors.Op("codec: write response")
+	const op = errors.Op("goridge_write_response")
 	fr := frame.NewFrame()
 
 	// SEQ_ID + METHOD_NAME_LEN
@@ -152,7 +152,7 @@ func (c *Codec) handleError(r *rpc.Response, fr *frame.Frame, buf *bytes.Buffer,
 // SEQ_ID: 15
 // METHOD_LEN: 12 and we take 12 bytes from the payload as method name
 func (c *Codec) ReadRequestHeader(r *rpc.Request) error {
-	const op = errors.Op("codec: read request header")
+	const op = errors.Op("goridge_read_request_header")
 	f := frame.NewFrame()
 	err := c.relay.Receive(f)
 	if err != nil {
@@ -194,7 +194,7 @@ func (c *Codec) storeCodec(r *rpc.Request, flag byte) error {
 // ReadRequestBody fetches prefixed body data and automatically unmarshal it as json. RawBody flag will populate
 // []byte lice argument for rpc method.
 func (c *Codec) ReadRequestBody(out interface{}) error {
-	const op = errors.Op("codec read request body")
+	const op = errors.Op("goridge_read_request_body")
 	if out == nil {
 		return nil
 	}

--- a/pkg/rpc/codec.go
+++ b/pkg/rpc/codec.go
@@ -52,7 +52,7 @@ func (c *Codec) WriteResponse(r *rpc.Response, body interface{}) error { //nolin
 		// fallback codec
 		fr.WriteFlags(frame.CODEC_GOB)
 	} else {
-		fr.WriteFlags(codec.(frame.Flag))
+		fr.WriteFlags(codec.(byte))
 	}
 
 	// delete the key
@@ -74,35 +74,35 @@ func (c *Codec) WriteResponse(r *rpc.Response, body interface{}) error { //nolin
 	flags := fr.ReadFlags()
 
 	switch {
-	case flags&byte(frame.CODEC_RAW) != 0:
+	case flags&frame.CODEC_RAW != 0:
 		err := encodeRaw(buf, body)
 		if err != nil {
 			return c.handleError(r, fr, buf, err)
 		}
 		// send buffer
 		return c.sendBuf(fr, buf)
-	case flags&byte(frame.CODEC_PROTO) != 0:
+	case flags&frame.CODEC_PROTO != 0:
 		err := encodeProto(buf, body)
 		if err != nil {
 			return c.handleError(r, fr, buf, err)
 		}
 		// send buffer
 		return c.sendBuf(fr, buf)
-	case flags&byte(frame.CODEC_JSON) != 0:
+	case flags&frame.CODEC_JSON != 0:
 		err := encodeJSON(buf, body)
 		if err != nil {
 			return c.handleError(r, fr, buf, err)
 		}
 		// send buffer
 		return c.sendBuf(fr, buf)
-	case flags&byte(frame.CODEC_MSGPACK) != 0:
+	case flags&frame.CODEC_MSGPACK != 0:
 		err := encodeMsgPack(buf, body)
 		if err != nil {
 			return c.handleError(r, fr, buf, err)
 		}
 		// send buffer
 		return c.sendBuf(fr, buf)
-	case flags&byte(frame.CODEC_GOB) != 0:
+	case flags&frame.CODEC_GOB != 0:
 		err := encodeGob(buf, body)
 		if err != nil {
 			return c.handleError(r, fr, buf, err)
@@ -174,15 +174,15 @@ func (c *Codec) ReadRequestHeader(r *rpc.Request) error {
 
 func (c *Codec) storeCodec(r *rpc.Request, flag byte) error {
 	switch {
-	case flag&byte(frame.CODEC_PROTO) != 0:
+	case flag&frame.CODEC_PROTO != 0:
 		c.codec.Store(r.Seq, frame.CODEC_PROTO)
-	case flag&byte(frame.CODEC_JSON) != 0:
+	case flag&frame.CODEC_JSON != 0:
 		c.codec.Store(r.Seq, frame.CODEC_JSON)
-	case flag&byte(frame.CODEC_RAW) != 0:
+	case flag&frame.CODEC_RAW != 0:
 		c.codec.Store(r.Seq, frame.CODEC_RAW)
-	case flag&byte(frame.CODEC_MSGPACK) != 0:
+	case flag&frame.CODEC_MSGPACK != 0:
 		c.codec.Store(r.Seq, frame.CODEC_MSGPACK)
-	case flag&byte(frame.CODEC_GOB) != 0:
+	case flag&frame.CODEC_GOB != 0:
 		c.codec.Store(r.Seq, frame.CODEC_GOB)
 	default:
 		c.codec.Store(r.Seq, frame.CODEC_GOB)
@@ -206,15 +206,15 @@ func (c *Codec) ReadRequestBody(out interface{}) error {
 	flags := c.frame.ReadFlags()
 
 	switch {
-	case flags&byte(frame.CODEC_PROTO) != 0:
+	case flags&frame.CODEC_PROTO != 0:
 		return decodeProto(out, c.frame)
-	case flags&byte(frame.CODEC_JSON) != 0:
+	case flags&frame.CODEC_JSON != 0:
 		return decodeJSON(out, c.frame)
-	case flags&byte(frame.CODEC_GOB) != 0:
+	case flags&frame.CODEC_GOB != 0:
 		return decodeGob(out, c.frame)
-	case flags&byte(frame.CODEC_RAW) != 0:
+	case flags&frame.CODEC_RAW != 0:
 		return decodeRaw(out, c.frame)
-	case flags&byte(frame.CODEC_MSGPACK) != 0:
+	case flags&frame.CODEC_MSGPACK != 0:
 		return decodeMsgPack(out, c.frame)
 	default:
 		return errors.E(op, errors.Str("unknown decoder used in frame"))

--- a/pkg/rpc/decoders.go
+++ b/pkg/rpc/decoders.go
@@ -12,7 +12,7 @@ import (
 )
 
 func decodeJSON(out interface{}, frame *frame.Frame) error {
-	const op = errors.Op("client: decode json")
+	const op = errors.Op("goridge_decode_json")
 	opts := frame.ReadOptions()
 	if len(opts) != 2 {
 		return errors.E(op, errors.Str("should be 2 options. SEQ_ID and METHOD_LEN"))
@@ -25,7 +25,7 @@ func decodeJSON(out interface{}, frame *frame.Frame) error {
 }
 
 func decodeGob(out interface{}, frame *frame.Frame) error {
-	const op = errors.Op("client: decode GOB")
+	const op = errors.Op("goridge_decode_gob")
 	opts := frame.ReadOptions()
 	if len(opts) != 2 {
 		return errors.E(op, errors.Str("should be 2 options. SEQ_ID and METHOD_LEN"))
@@ -43,7 +43,7 @@ func decodeGob(out interface{}, frame *frame.Frame) error {
 }
 
 func decodeProto(out interface{}, frame *frame.Frame) error {
-	const op = errors.Op("client: decode PROTO")
+	const op = errors.Op("goridge_decode_proto")
 	opts := frame.ReadOptions()
 	if len(opts) != 2 {
 		return errors.E(op, errors.Str("should be 2 options. SEQ_ID and METHOD_LEN"))
@@ -62,7 +62,7 @@ func decodeProto(out interface{}, frame *frame.Frame) error {
 }
 
 func decodeRaw(out interface{}, frame *frame.Frame) error {
-	const op = errors.Op("client: decode raw")
+	const op = errors.Op("goridge_decode_raw")
 	opts := frame.ReadOptions()
 	if len(opts) != 2 {
 		return errors.E(op, errors.Str("should be 2 options. SEQ_ID and METHOD_LEN"))
@@ -81,7 +81,7 @@ func decodeRaw(out interface{}, frame *frame.Frame) error {
 }
 
 func decodeMsgPack(out interface{}, frame *frame.Frame) error {
-	const op = errors.Op("client: decode msgpack")
+	const op = errors.Op("goridge_decodemsgpack")
 	opts := frame.ReadOptions()
 	if len(opts) != 2 {
 		return errors.E(op, errors.Str("should be 2 options. SEQ_ID and METHOD_LEN"))

--- a/pkg/rpc/encoders.go
+++ b/pkg/rpc/encoders.go
@@ -11,7 +11,7 @@ import (
 )
 
 func encodeJSON(out io.Writer, data interface{}) error {
-	const op = errors.Op("codec: encode json")
+	const op = errors.Op("goridge_encode_json")
 
 	res, err := json.Marshal(data)
 	if err != nil {
@@ -25,7 +25,7 @@ func encodeJSON(out io.Writer, data interface{}) error {
 }
 
 func encodeGob(out io.Writer, data interface{}) error {
-	const op = errors.Op("codec: encode GOB")
+	const op = errors.Op("goridge_encode_gob")
 
 	dec := gob.NewEncoder(out)
 	err := dec.Encode(data)
@@ -36,7 +36,7 @@ func encodeGob(out io.Writer, data interface{}) error {
 }
 
 func encodeProto(out io.Writer, data interface{}) error {
-	const op = errors.Op("codec: encode PROTO")
+	const op = errors.Op("goridge_encode_proto")
 
 	d, err := proto.Marshal(data.(proto.Message))
 	if err != nil {
@@ -51,7 +51,7 @@ func encodeProto(out io.Writer, data interface{}) error {
 }
 
 func encodeRaw(out io.Writer, data interface{}) error {
-	const op = errors.Op("codec: encode raw")
+	const op = errors.Op("goridge_encode_raw")
 	switch data := data.(type) {
 	case []byte:
 		_, err := out.Write(data)
@@ -73,7 +73,7 @@ func encodeRaw(out io.Writer, data interface{}) error {
 }
 
 func encodeMsgPack(out io.Writer, data interface{}) error {
-	const op = errors.Op("codec: encode msgpack")
+	const op = errors.Op("goridge_encode_msgpack")
 	b, err := msgpack.Marshal(data)
 	if err != nil {
 		return errors.E(op, err)

--- a/pkg/socket/socket.go
+++ b/pkg/socket/socket.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spiral/goridge/v3/pkg/frame"
 )
 
-// SocketRelay communicates with underlying process using sockets (TPC or Unix).
+// Relay communicates with underlying process using sockets (TPC or Unix).
 type Relay struct {
 	rwc io.ReadWriteCloser
 }


### PR DESCRIPTION
# Reason for This PR

- Refactor
closes #100 

## Description of Changes

- Remove byte (Frame) type aliases to prevent casting in hot places
- Fix linter warnings

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`) or (`git commit -S`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
