### PR TITLE
bug(proto): incorrect proto interface casting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 CHANGELOG
 =========
 
+v3.1.2 (10.06.2021)
+-------------------
+
+## 🩹 Fixes:
+
+- 🐛 Fix: Bug with incorrect proto interface casting which leads to a panic.
+
+---
+
+v3.1.1 (09.06.2021)
+-------------------
+
+## 🚀 New:
+
+- ✏️ Standardise error operations in the whole project.
+- ✏️ Remove `frame` to `byte` type aliasing in hot paths.
+
+---
+
 v3.1.0 (09.06.2021)
 -------------------
 

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -98,7 +98,7 @@ func (c *ClientCodec) WriteRequest(r *rpc.Request,
 
 // ReadResponseHeader reads response from the connection.
 func (c *ClientCodec) ReadResponseHeader(r *rpc.Response) error {
-	const op = errors.Op("client codec ReadResponseHeader")
+	const op = errors.Op("client_read_response_header")
 	fr := frame.NewFrame()
 	err := c.relay.Receive(fr)
 	if err != nil {
@@ -129,7 +129,7 @@ func (c *ClientCodec) ReadResponseHeader(r *rpc.Response) error {
 
 // ReadResponseBody response from the connection.
 func (c *ClientCodec) ReadResponseBody(out interface{}) error {
-	const op = errors.Op("client ReadResponseBody")
+	const op = errors.Op("client_read_response_body")
 	defer func() {
 		// reset the frame
 		c.frame = nil

--- a/pkg/rpc/codec.go
+++ b/pkg/rpc/codec.go
@@ -114,6 +114,7 @@ func (c *Codec) WriteResponse(r *rpc.Response, body interface{}) error { //nolin
 	}
 }
 
+//go:inline
 func (c *Codec) sendBuf(frame *frame.Frame, buf *bytes.Buffer) error {
 	frame.WritePayloadLen(uint32(buf.Len()))
 	frame.WritePayload(buf.Bytes())
@@ -172,6 +173,7 @@ func (c *Codec) ReadRequestHeader(r *rpc.Request) error {
 	return c.storeCodec(r, f.ReadFlags())
 }
 
+//go:inline
 func (c *Codec) storeCodec(r *rpc.Request, flag byte) error {
 	switch {
 	case flag&frame.CODEC_PROTO != 0:

--- a/pkg/rpc/decoders.go
+++ b/pkg/rpc/decoders.go
@@ -53,12 +53,17 @@ func decodeProto(out interface{}, frame *frame.Frame) error {
 		return nil
 	}
 
-	err := proto.Unmarshal(payload, out.(proto.Message))
-	if err != nil {
-		return errors.E(op, err)
+	// check if the out message is a correct proto.Message
+	// instead send an error
+	if pOut, ok := out.(proto.Message); ok {
+		err := proto.Unmarshal(payload, pOut)
+		if err != nil {
+			return errors.E(op, err)
+		}
+		return nil
 	}
 
-	return nil
+	return errors.E(op, errors.Str("message type is not a proto"))
 }
 
 func decodeRaw(out interface{}, frame *frame.Frame) error {


### PR DESCRIPTION
# Reason for This PR

- panic when passing non-proto payload with the `CODEC_PROTO`

## Description of Changes

- Inject some `go:inline` directives.
- Update function comments.
- Make proto interface casting properly.
- Add test for the incorrect proto-type casting.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`) or (`git commit -S`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
