### PR TITLE
perf/bug(frame): api stabilization, fix bug with incorrect AND operation while reading the header len

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ v3.2.0 (-.08.2021)
 ## 🚀 New:
 
 - ✏️ 50% reduce bound checks in the frame's operations. [PR](https://github.com/spiral/goridge/pull/143)
+-
+
+## 🩹 Fixes:
+
+- 🐛 Fix: bug with incorrectly interpreted header len AND operation.
 
 ## 🔨 BC:
 

--- a/pkg/pipe/pipe_test.go
+++ b/pkg/pipe/pipe_test.go
@@ -17,7 +17,7 @@ func TestPipeReceive(t *testing.T) {
 
 	nf := frame.NewFrame()
 	nf.WriteVersion(nf.Header(), frame.VERSION_1)
-	nf.WriteFlags(frame.CONTROL, frame.CODEC_GOB, frame.CODEC_JSON)
+	nf.WriteFlags(nf.Header(), frame.CONTROL, frame.CODEC_GOB, frame.CODEC_JSON)
 	nf.WritePayloadLen(nf.Header(), uint32(len([]byte(TestPayload))))
 	nf.WritePayload([]byte(TestPayload))
 	nf.WriteCRC(nf.Header())
@@ -52,7 +52,7 @@ func TestPipeReceiveWithOptions(t *testing.T) {
 
 	nf := frame.NewFrame()
 	nf.WriteVersion(nf.Header(), frame.VERSION_1)
-	nf.WriteFlags(frame.CONTROL, frame.CODEC_GOB, frame.CODEC_JSON)
+	nf.WriteFlags(nf.Header(), frame.CONTROL, frame.CODEC_GOB, frame.CODEC_JSON)
 	nf.WritePayloadLen(nf.Header(), uint32(len([]byte(TestPayload))))
 	nf.WritePayload([]byte(TestPayload))
 	nf.WriteOptions(nf.HeaderPtr(), 100, 10000, 100000)
@@ -89,7 +89,7 @@ func TestPipeCRC_Failed(t *testing.T) {
 
 	nf := frame.NewFrame()
 	nf.WriteVersion(nf.Header(), frame.VERSION_1)
-	nf.WriteFlags(frame.CONTROL)
+	nf.WriteFlags(nf.Header(), frame.CONTROL)
 	nf.WritePayloadLen(nf.Header(), uint32(len([]byte(TestPayload))))
 
 	assert.Equal(t, false, nf.VerifyCRC(nf.Header()))

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -73,14 +73,14 @@ func (c *ClientCodec) WriteRequest(r *rpc.Request, body interface{}) error {
 	// writeServiceMethod to the buffer
 	buf.WriteString(r.ServiceMethod)
 	// use fallback as gob
-	fr.WriteFlags(frame.CODEC_GOB)
+	fr.WriteFlags(fr.Header(), frame.CODEC_GOB)
 
 	if body != nil {
 		// if body is proto message, use proto codec
 		switch m := body.(type) {
 		// check if message is PROTO
 		case proto.Message:
-			fr.WriteFlags(frame.CODEC_PROTO)
+			fr.WriteFlags(fr.Header(), frame.CODEC_PROTO)
 			b, err := proto.Marshal(m)
 			if err != nil {
 				return errors.E(op, err)

--- a/pkg/rpc/codec.go
+++ b/pkg/rpc/codec.go
@@ -79,9 +79,9 @@ func (c *Codec) WriteResponse(r *rpc.Response, body interface{}) error { //nolin
 	codec, ok := c.codec.Load(r.Seq)
 	if !ok {
 		// fallback codec
-		fr.WriteFlags(frame.CODEC_GOB)
+		fr.WriteFlags(fr.Header(), frame.CODEC_GOB)
 	} else {
-		fr.WriteFlags(codec.(byte))
+		fr.WriteFlags(fr.Header(), codec.(byte))
 	}
 
 	// delete the key
@@ -162,7 +162,7 @@ func (c *Codec) handleError(r *rpc.Response, fr *frame.Frame, err string) error 
 	buf.WriteString(r.ServiceMethod)
 
 	const op = errors.Op("handle codec error")
-	fr.WriteFlags(frame.ERROR)
+	fr.WriteFlags(fr.Header(), frame.ERROR)
 	// error should be here
 	if err != "" {
 		buf.WriteString(err)

--- a/pkg/socket/socket_test.go
+++ b/pkg/socket/socket_test.go
@@ -18,7 +18,7 @@ func TestSocketRelay(t *testing.T) {
 	// TEST FRAME TO SEND
 	nf := frame.NewFrame()
 	nf.WriteVersion(nf.Header(), frame.VERSION_1)
-	nf.WriteFlags(frame.CONTROL, frame.CODEC_GOB, frame.CODEC_JSON)
+	nf.WriteFlags(nf.Header(), frame.CONTROL, frame.CODEC_GOB, frame.CODEC_JSON)
 	nf.WritePayloadLen(nf.Header(), uint32(len([]byte(TestPayload))))
 	nf.WritePayload([]byte(TestPayload))
 	nf.WriteCRC(nf.Header())
@@ -57,7 +57,7 @@ func TestSocketRelayOptions(t *testing.T) {
 	// TEST FRAME TO SEND
 	nf := frame.NewFrame()
 	nf.WriteVersion(nf.Header(), frame.VERSION_1)
-	nf.WriteFlags(frame.CONTROL, frame.CODEC_GOB, frame.CODEC_JSON)
+	nf.WriteFlags(nf.Header(), frame.CONTROL, frame.CODEC_GOB, frame.CODEC_JSON)
 	nf.WritePayloadLen(nf.Header(), uint32(len([]byte(TestPayload))))
 	nf.WritePayload([]byte(TestPayload))
 	nf.WriteOptions(nf.HeaderPtr(), 100, 10000, 100000)
@@ -98,7 +98,7 @@ func TestSocketRelayNoPayload(t *testing.T) {
 	// TEST FRAME TO SEND
 	nf := frame.NewFrame()
 	nf.WriteVersion(nf.Header(), frame.VERSION_1)
-	nf.WriteFlags(frame.CONTROL, frame.CODEC_GOB, frame.CODEC_JSON)
+	nf.WriteFlags(nf.Header(), frame.CONTROL, frame.CODEC_GOB, frame.CODEC_JSON)
 	nf.WriteOptions(nf.HeaderPtr(), 100, 10000, 100000)
 	nf.WriteCRC(nf.Header())
 	assert.Equal(t, true, nf.VerifyCRC(nf.Header()))
@@ -137,7 +137,7 @@ func TestSocketRelayWrongCRC(t *testing.T) {
 	// TEST FRAME TO SEND
 	nf := frame.NewFrame()
 	nf.WriteVersion(nf.Header(), frame.VERSION_1)
-	nf.WriteFlags(frame.CONTROL, frame.CODEC_GOB, frame.CODEC_JSON)
+	nf.WriteFlags(nf.Header(), frame.CONTROL, frame.CODEC_GOB, frame.CODEC_JSON)
 	nf.WriteOptions(nf.HeaderPtr(), 100, 10000, 100000)
 	nf.WriteCRC(nf.Header())
 	nf.Header()[6] = 22 // just random wrong CRC directly


### PR DESCRIPTION
# Reason for This PR

- API stabilization
- Bug with incorrect AND operation while reading the header len.

## Description of Changes

- Fix bug with AND operation in the `incrementHL` method.
- Add tests.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`) or (`git commit -S`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
